### PR TITLE
Refactor Github.Client

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -44,3 +44,6 @@ config :elixir_bench, ElixirBench.Repo,
   database: "elixir_bench_dev",
   hostname: "localhost",
   pool_size: 10
+
+# Set the Github client
+config :elixir_bench, :github_client, ElixirBench.Github.ClientHTTP

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -51,3 +51,6 @@ config :elixir_bench, ElixirBenchWeb.Endpoint, server: true
 # Finally import the config/prod.secret.exs
 # which should be versioned separately.
 import_config "prod.secret.exs"
+
+# Set the Github client
+config :elixir_bench, :github_client, ElixirBench.Github.ClientHTTP

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,6 @@ config :elixir_bench, ElixirBench.Repo,
   database: "elixir_bench_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+# Set the Github client
+config :elixir_bench, :github_client, ElixirBench.Github.ClientInMemory

--- a/lib/elixir_bench/github/client.ex
+++ b/lib/elixir_bench/github/client.ex
@@ -1,44 +1,20 @@
 defmodule ElixirBench.Github.Client do
-  alias ElixirBench.Github.Client
+  @moduledoc """
+  The Github client specification.
 
-  defstruct [:base_url, ssl_options: []]
+  This module defines an interface for writing Github clients. The
+  clients provide the api to get the raw configuration based on the
+  benchee.yml file of the target repository. Their implementation can follow
+  different protocol interfaces, like the `ElixirBench.Github.ClientHTTP`
+  module or a client can be defined with testing pourposes, to be used as mock,
+  like in `ElixirBench.Github.ClientInMemory`.
 
-  def get_plain(%Client{} = client, url, params \\ []) do
-    get(client, url(client, url, params), [{"accept", "text/plain"}], &(&1))
-  end
+  A module that implements the Github client behaviour must export:
 
-  def get_json(%Client{} = client, url, params \\ []) do
-    get(client, url(client, url, params), [{"accept", "application/json"}], &Antidote.decode/1)
-  end
+    - a `get_yaml/1` function that takes the url path of the project and returns
+    a map with the configuration found in the benchee.yml that is stored
+    inside the `benchee directory`.
+  """
 
-  def get_yaml(%Client{} = client, url, params \\ []) do
-    get(client, url(client, url, params), [{"accept", "application/yaml"}], &decode_yaml/1)
-  end
-
-  @doc false
-  # Public for testing purposes
-  def decode_yaml(content) do
-    case :yamerl.decode(content, [:str_node_as_binary, map_node_format: :map]) do
-      [parsed] -> {:ok, parsed}
-      _ -> {:error, :invalid}
-    end
-  end
-
-  defp get(client, url, headers, cb) do
-    ssl_options = client.ssl_options
-    options = [:with_body, ssl_options: ssl_options]
-
-    case :hackney.get(url, headers, <<>>, options) do
-      {:ok, 200, _headers, data} ->
-        cb.(data)
-      {:ok, status, _headers, data} ->
-        {:error, {status, data}}
-      {:error, error} ->
-        {:error, error}
-    end
-  end
-
-  defp url(%{base_url: base}, url, params) do
-    Path.join(base, url) <> "?" <> URI.encode_query(params)
-  end
+  @callback get_yaml(path :: String) :: {:ok, config :: Map} | {:error, reason :: term}
 end

--- a/lib/elixir_bench/github/client.ex
+++ b/lib/elixir_bench/github/client.ex
@@ -8,13 +8,7 @@ defmodule ElixirBench.Github.Client do
   different protocol interfaces, like the `ElixirBench.Github.ClientHTTP`
   module or a client can be defined with testing pourposes, to be used as mock,
   like in `ElixirBench.Github.ClientInMemory`.
-
-  A module that implements the Github client behaviour must export:
-
-    - a `get_yaml/1` function that takes the url path of the project and returns
-    a map with the configuration found in the benchee.yml that is stored
-    inside the `benchee directory`.
   """
 
-  @callback get_yaml(path :: String) :: {:ok, config :: Map} | {:error, reason :: term}
+  @callback get_yaml(path :: String.t) :: {:ok, config :: Map.t} | {:error, reason :: term}
 end

--- a/lib/elixir_bench/github/client_http.ex
+++ b/lib/elixir_bench/github/client_http.ex
@@ -1,0 +1,50 @@
+defmodule ElixirBench.Github.ClientHTTP do
+  @moduledoc """
+  The Github HTTP client.
+
+  This client uses HTTP requests to gather data from yml files in given
+  repository hosted on Github. It uses the `:hackney` library to actually send
+  the requests and the `yamerl` library to decode the data in the yml format.
+
+  Requests follow a base url:
+
+    - base_url = 'https://raw.githubusercontent.com'
+
+  This module implements the following functions:
+
+    - a `get_yaml/1` function that takes the url path of the project and return
+      the raw parsed data in the yaml format.
+  """
+
+  @behaviour ElixirBench.Github.Client
+
+  def get_yaml(path) do
+    get(url(path), [{"accept", "application/yaml"}], &decode_yaml/1)
+  end
+
+  @doc false
+  defp decode_yaml(content) do
+    case :yamerl.decode(content, [:str_node_as_binary, map_node_format: :map]) do
+      [parsed] -> {:ok, parsed}
+      _ -> {:error, :invalid}
+    end
+  end
+
+  defp get(url, headers, callback) do
+    options = [:with_body, ssl_options: []]
+
+    case :hackney.get(url, headers, <<>>, options) do
+      {:ok, 200, _headers, data} ->
+        callback.(data)
+      {:ok, status, _headers, data} ->
+        {:error, {status, data}}
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp url(path) do
+    base_url = 'https://raw.githubusercontent.com'
+    Path.join(base_url, path)
+  end
+end

--- a/lib/elixir_bench/github/client_http.ex
+++ b/lib/elixir_bench/github/client_http.ex
@@ -2,18 +2,10 @@ defmodule ElixirBench.Github.ClientHTTP do
   @moduledoc """
   The Github HTTP client.
 
-  This client uses HTTP requests to gather data from yml files in given
-  repository hosted on Github. It uses the `:hackney` library to actually send
-  the requests and the `yamerl` library to decode the data in the yml format.
+  This client uses HTTP requests to gather data from yml files in a given
+  repository hosted on Github.
 
-  Requests follow a base url:
-
-    - base_url = 'https://raw.githubusercontent.com'
-
-  This module implements the following functions:
-
-    - a `get_yaml/1` function that takes the url path of the project and return
-      the raw parsed data in the yaml format.
+  Requests follow the base url: 'https://raw.githubusercontent.com'
   """
 
   @behaviour ElixirBench.Github.Client
@@ -33,7 +25,7 @@ defmodule ElixirBench.Github.ClientHTTP do
   defp get(url, headers, callback) do
     options = [:with_body, ssl_options: []]
 
-    case :hackney.get(url, headers, <<>>, options) do
+    case :hackney.get(url, headers, "", options) do
       {:ok, 200, _headers, data} ->
         callback.(data)
       {:ok, status, _headers, data} ->
@@ -44,7 +36,6 @@ defmodule ElixirBench.Github.ClientHTTP do
   end
 
   defp url(path) do
-    base_url = 'https://raw.githubusercontent.com'
-    Path.join(base_url, path)
+    Path.join("https://raw.githubusercontent.com", path)
   end
 end

--- a/lib/elixir_bench/github/client_in_memory.ex
+++ b/lib/elixir_bench/github/client_in_memory.ex
@@ -3,41 +3,34 @@ defmodule ElixirBench.Github.ClientInMemory do
   The Github InMemory client.
 
   This client is a mock module to be used in tests.
-
-  This module implements the following functions:
-
-    - a `get_yaml/1` function that takes the url path of the project and return
-      a map with mocked data about the raw configuration found in the
-      benchee.yml file.
   """
 
   @behaviour ElixirBench.Github.Client
 
   def get_yaml(_) do
     {:ok,
-      %{
-        "deps" => %{
-          "docker" => [
-            %{
-              "container_name" => "postgres",
-              "image" => "postgres:9.6.6-alpine"
-            },
-            %{
-              "container_name" => "mysql",
-              "environment" => %{
-                "MYSQL_ALLOW_EMPTY_PASSWORD" => "true"
-              },
-              "image" => "mysql:5.7.20"
-            }
-          ]
-        },
-        "elixir" => "1.5.2",
-        "environment" => %{
-          "MYSQL_URL" => "root@localhost",
-          "PG_URL" => "postgres:postgres@localhost"
-        },
-        "erlang" => "20.1.2"
-      }
-    }
+     %{
+       "deps" => %{
+         "docker" => [
+           %{
+             "container_name" => "postgres",
+             "image" => "postgres:9.6.6-alpine"
+           },
+           %{
+             "container_name" => "mysql",
+             "environment" => %{
+               "MYSQL_ALLOW_EMPTY_PASSWORD" => "true"
+             },
+             "image" => "mysql:5.7.20"
+           }
+         ]
+       },
+       "elixir" => "1.5.2",
+       "environment" => %{
+         "MYSQL_URL" => "root@localhost",
+         "PG_URL" => "postgres:postgres@localhost"
+       },
+       "erlang" => "20.1.2"
+     }}
   end
 end

--- a/lib/elixir_bench/github/client_in_memory.ex
+++ b/lib/elixir_bench/github/client_in_memory.ex
@@ -1,0 +1,43 @@
+defmodule ElixirBench.Github.ClientInMemory do
+  @moduledoc """
+  The Github InMemory client.
+
+  This client is a mock module to be used in tests.
+
+  This module implements the following functions:
+
+    - a `get_yaml/1` function that takes the url path of the project and return
+      a map with mocked data about the raw configuration found in the
+      benchee.yml file.
+  """
+
+  @behaviour ElixirBench.Github.Client
+
+  def get_yaml(_) do
+    {:ok,
+      %{
+        "deps" => %{
+          "docker" => [
+            %{
+              "container_name" => "postgres",
+              "image" => "postgres:9.6.6-alpine"
+            },
+            %{
+              "container_name" => "mysql",
+              "environment" => %{
+                "MYSQL_ALLOW_EMPTY_PASSWORD" => "true"
+              },
+              "image" => "mysql:5.7.20"
+            }
+          ]
+        },
+        "elixir" => "1.5.2",
+        "environment" => %{
+          "MYSQL_URL" => "root@localhost",
+          "PG_URL" => "postgres:postgres@localhost"
+        },
+        "erlang" => "20.1.2"
+      }
+    }
+  end
+end

--- a/lib/elixir_bench/github/github.ex
+++ b/lib/elixir_bench/github/github.ex
@@ -1,13 +1,13 @@
 defmodule ElixirBench.Github do
   require Logger
 
-  alias ElixirBench.Github.Client
+  @github_client Application.get_env(:elixir_bench, :github_client)
 
   def fetch_config(repo_owner, repo_name, branch_or_commit) do
     path = [repo_owner, "/", repo_name, "/", branch_or_commit, "/bench/config.yml"]
     slug = "#{repo_owner}/#{repo_name}##{branch_or_commit}"
     Logger.info("Requesting bench config for: #{slug}")
-    case Client.get_yaml(raw_client(), path) do
+    case @github_client.get_yaml(path) do
       {:ok, config} ->
         {:ok, config}
       {:error, {404, _}} ->
@@ -16,9 +16,5 @@ defmodule ElixirBench.Github do
         Logger.error("Failed to fetch config for #{slug}: #{inspect reason}")
         {:error, :failed_config_fetch}
     end
-  end
-
-  def raw_client() do
-    %Client{base_url: "https://raw.githubusercontent.com"}
   end
 end

--- a/test/elixir_bench/benchmarks/benchmarks_test.exs
+++ b/test/elixir_bench/benchmarks/benchmarks_test.exs
@@ -1,0 +1,18 @@
+defmodule ElixirBench.BenchmarksTest do
+  use ElixirBench.DataCase
+  alias ElixirBench.{Benchmarks, Benchmarks.Job}
+  alias ElixirBench.Repos
+
+  describe "when correct params" do
+    test "create_job/2 should return new Job" do
+      {:ok, repo} = Repos.create_repo(%{owner: "elixir-ecto", name: "ecto"})
+      job_attrs = %{branch_name: "mm/benche", commit_sha: "ABC123"}
+
+      jobs_count = ElixirBench.Repo.all(Job) |> length
+      assert {:ok, %Job{}} = Benchmarks.create_job(repo, job_attrs)
+
+      new_count = ElixirBench.Repo.all(Job) |> length
+      assert new_count > jobs_count
+    end
+  end
+end

--- a/test/elixir_bench/benchmarks/benchmarks_test.exs
+++ b/test/elixir_bench/benchmarks/benchmarks_test.exs
@@ -3,15 +3,15 @@ defmodule ElixirBench.BenchmarksTest do
   alias ElixirBench.{Benchmarks, Benchmarks.Job}
   alias ElixirBench.Repos
 
-  describe "when correct params" do
-    test "create_job/2 should return new Job" do
+  describe "create_job/2" do
+    test "return a new Job given correct params" do
       {:ok, repo} = Repos.create_repo(%{owner: "elixir-ecto", name: "ecto"})
       job_attrs = %{branch_name: "mm/benche", commit_sha: "ABC123"}
 
-      jobs_count = ElixirBench.Repo.all(Job) |> length
+      jobs_count = Repo.aggregate(Job, :count, :id)
       assert {:ok, %Job{}} = Benchmarks.create_job(repo, job_attrs)
 
-      new_count = ElixirBench.Repo.all(Job) |> length
+      new_count = Repo.aggregate(Job, :count, :id)
       assert new_count > jobs_count
     end
   end


### PR DESCRIPTION
The GitHub.Client was very coupled, so I made a refactor based on [this post](http://blog.plataformatec.com.br/2015/10/mocks-and-explicit-contracts) from Jose Valim that explains how to properly use mocks  and define contracts.