### PR TITLE
WIP: Adds max retries to Job

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,8 @@ config :elixir_bench,
        :supported_erlang_versions,
        {:system, :list, "SUPPORTED_ERLANG_VERSIONS", ["20.1.2"]}
 
+config :elixir_bench, :job_max_retries, {:system, :integer, "JOB_MAX_RETRIES", 3}
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/priv/repo/migrations/20180815140601_adds_claims_count_to_jobs.exs
+++ b/priv/repo/migrations/20180815140601_adds_claims_count_to_jobs.exs
@@ -1,0 +1,14 @@
+defmodule ElixirBench.Repo.Migrations.AddsClaimsCountToJobs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:jobs) do
+      add :claim_count, :integer, default: 0
+    end
+
+    # assume all existent jobs has being claimed once
+    execute """
+    UPDATE jobs SET claim_count = 1 WHERE claimed_by IS NOT NULL;
+    """, "" # nothing on down
+  end
+end

--- a/test/elixir_bench/benchmarks/benchmarks_test.exs
+++ b/test/elixir_bench/benchmarks/benchmarks_test.exs
@@ -199,6 +199,20 @@ defmodule ElixirBench.BenchmarksTest do
       assert %Job{id: ^jid, claimed_by: ^rid} = job
     end
 
+    test "return error when max retries limit is reached" do
+      %{id: jid, claimed_by: nil} = insert(:job)
+      %{id: rid} = runner = insert(:runner)
+
+      max_retries = Confex.fetch_env!(:elixir_bench, :job_max_retries)
+
+      1..max_retries
+      |> Enum.each(fn _ ->
+        assert {:ok, job} = Benchmarks.claim_job(runner)
+      end)
+
+      assert {:error, :not_found} = Benchmarks.claim_job(runner)
+    end
+
     test "return error if there is no pending jobs" do
       runner = insert(:runner)
 


### PR DESCRIPTION
A few considerations here:

**Consideration 1**
I've added two ways of incrementing `claim_count`.
1. First one is just doing `claim_count + 1`
1. Second one is a method `increment_claim_count` which is binded by `prepare_changes` to increment `claim_count` when the changeset transaction is completed.

From my point of view, first approach works and do not seems to present too much trouble considering possible concurrency between the runners queries.

**Consideration 2**
Do we need this configuration to be in the environment or something or are you ok with a module attr `@max_retries 3`?