### PR TITLE
Fix broken link to logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="../web/public/images/logo.png" height="68" />
+<img src="https://github.com/elixir-bench/elixir-bench.github.io/blob/master/images/logo.png" height="68" />
 
 # ElixirBench API
 


### PR DESCRIPTION
Saw it, had some free time to spend and just fixed the link.

I used the same link as in the https://github.com/elixir-bench/elixir-bench-runner repo.