### PR TITLE
Limit jobs and add pagination

### DIFF
--- a/lib/elixir_bench/benchmarks/benchmarks.ex
+++ b/lib/elixir_bench/benchmarks/benchmarks.ex
@@ -7,6 +7,9 @@ defmodule ElixirBench.Benchmarks do
   alias ElixirBench.Github
   alias ElixirBench.Benchmarks.{Benchmark, Measurement, Job, Runner, Config}
 
+  @jobs_default_limit 10
+  @jobs_max_limit 50
+
   def data() do
     Dataloader.Ecto.new(Repo, query: &query/2)
   end
@@ -69,8 +72,23 @@ defmodule ElixirBench.Benchmarks do
     Repo.all(from(j in Job, where: j.repo_id in ^repo_ids))
   end
 
+  def paginate(query, page, size) do
+    from(query,
+      limit: ^size,
+      offset: ^((page - 1) * size)
+    )
+  end
+
   def list_jobs() do
-    Repo.all(Job)
+    Job
+    |> paginate(1, @jobs_default_limit)
+    |> Repo.all()
+  end
+
+  def list_jobs(page, size) do
+    Job
+    |> paginate(page, size)
+    |> Repo.all()
   end
 
   def get_or_create_job(repo, %{commit_sha: commit_sha} = attrs) do

--- a/test/elixir_bench/jobs/jobs_test.exs
+++ b/test/elixir_bench/jobs/jobs_test.exs
@@ -1,0 +1,31 @@
+defmodule ElixirBench.JobsTest do
+  use ElixirBench.DataCase
+  import ElixirBench.Factory
+  alias ElixirBench.Benchmarks
+
+  setup do
+    Enum.each(0..4, fn _ -> insert(:job) end)
+  end
+
+  describe "list_jobs/2" do
+    test "returns 2 jobs for page 1" do
+      jobs = Benchmarks.list_jobs(1, 2)
+      assert length(jobs) == 2
+    end
+
+    test "returns 2 jobs for page 2" do
+      jobs = Benchmarks.list_jobs(2, 2)
+      assert length(jobs) == 2
+    end
+
+    test "returns 1 job for page 3" do
+      jobs = Benchmarks.list_jobs(3, 2)
+      assert length(jobs) == 1
+    end
+
+    test "without page returns all 5 jobs" do
+      jobs = Benchmarks.list_jobs()
+      assert length(jobs) == 5
+    end
+  end
+end


### PR DESCRIPTION
⚠️ 🚧 **WIP** for https://github.com/elixir-bench/elixir-bench-api/issues/49

- [x] add pagination for jobs in the data layer, with default of 10 jobs
- [ ] add limit of 50 jobs
- [ ] add pagination in the GraphQL layer